### PR TITLE
update-istex-theme-before-v12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM inistcnrs/lodex:12.0.2
+FROM inistcnrs/lodex:11.16.3
 
 COPY . /app/src/app/custom


### PR DESCRIPTION
needs to update Istex theme to be applied to version 11.16.3 of Lodex